### PR TITLE
Feature: Metamask via `window.ethereum`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6895,9 +6895,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001230",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+      "version": "1.0.30001231",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001231.tgz",
+      "integrity": "sha512-WAFFv31GgU4DiwNAy77qMo3nNyycEhH3ikcCVHvkQpPe/fO8Tb2aRYzss8kgyLQBm8mJ7OryW4X6Y4vsBCIqag==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -6954,9 +6954,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.2.tgz",
-      "integrity": "sha512-Mzv+gp5dOGrABoobxhuY9Os+zaQs5pvHXMoMfEWo5gzdrcF4kO4KL4mG/7XbmJ8nqLrJkPlp/1tqgvcTpiHU9A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.3.tgz",
+      "integrity": "sha512-VN5MgyNDis2udgHm+gZy+FoB8LFSmML7gfoxe32x0DMfoBxbvRGnZQrTub/Us8mhLinIMd9zWE8swr/fcmwLvA==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -10750,9 +10750,9 @@
       "integrity": "sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w=="
     },
     "node_modules/execa": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.1.tgz",
+      "integrity": "sha512-4hFTjFbFzQa3aCLobpbPJR/U+VoL1wdV5ozOWjeet0AWDeYr9UFGM1eUFWHX+VtOWFq4p0xXUXfW1YxUaP4fpw==",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -18622,9 +18622,9 @@
       }
     },
     "node_modules/jsdom/node_modules/acorn": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
-      "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.3.0.tgz",
+      "integrity": "sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -20225,9 +20225,9 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -20239,6 +20239,14 @@
       "dependencies": {
         "mime-db": "1.47.0"
       },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -23589,9 +23597,9 @@
       }
     },
     "node_modules/polished": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.1.tgz",
-      "integrity": "sha512-/QgHrNGYwIA4mwxJ/7FSvalUJsm7KNfnXiScVSEG2Xa5qxDeBn4nmdjN2pW00mkM2Tts64ktc47U8F7Ed1BRAA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
+      "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -38886,9 +38894,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001230",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ=="
+      "version": "1.0.30001231",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001231.tgz",
+      "integrity": "sha512-WAFFv31GgU4DiwNAy77qMo3nNyycEhH3ikcCVHvkQpPe/fO8Tb2aRYzss8kgyLQBm8mJ7OryW4X6Y4vsBCIqag=="
     },
     "capital-case": {
       "version": "1.0.4",
@@ -38932,9 +38940,9 @@
       "integrity": "sha512-aD/WmxhGwUGsVPrj8C80vH7C7GphJilYVSdudoV4u16XdrLF7CVyfBmENsc4tLTVsJJzCRid8GbwJ7mcPLee6Q=="
     },
     "cborg": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.2.tgz",
-      "integrity": "sha512-Mzv+gp5dOGrABoobxhuY9Os+zaQs5pvHXMoMfEWo5gzdrcF4kO4KL4mG/7XbmJ8nqLrJkPlp/1tqgvcTpiHU9A=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.3.tgz",
+      "integrity": "sha512-VN5MgyNDis2udgHm+gZy+FoB8LFSmML7gfoxe32x0DMfoBxbvRGnZQrTub/Us8mhLinIMd9zWE8swr/fcmwLvA=="
     },
     "chai": {
       "version": "4.3.4",
@@ -41878,9 +41886,9 @@
       "integrity": "sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w=="
     },
     "execa": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.1.tgz",
+      "integrity": "sha512-4hFTjFbFzQa3aCLobpbPJR/U+VoL1wdV5ozOWjeet0AWDeYr9UFGM1eUFWHX+VtOWFq4p0xXUXfW1YxUaP4fpw==",
       "requires": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -48105,9 +48113,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.2.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
-          "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg=="
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.3.0.tgz",
+          "integrity": "sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw=="
         },
         "form-data": {
           "version": "3.0.1",
@@ -49445,9 +49453,9 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
     },
     "mime-types": {
       "version": "2.1.30",
@@ -49455,6 +49463,13 @@
       "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
       "requires": {
         "mime-db": "1.47.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.47.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+          "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+        }
       }
     },
     "mimic-fn": {
@@ -52069,9 +52084,9 @@
       }
     },
     "polished": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.1.tgz",
-      "integrity": "sha512-/QgHrNGYwIA4mwxJ/7FSvalUJsm7KNfnXiScVSEG2Xa5qxDeBn4nmdjN2pW00mkM2Tts64ktc47U8F7Ed1BRAA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
+      "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
       "requires": {
         "@babel/runtime": "^7.12.5"
       }

--- a/src/components/ConnectToWalletButton.js
+++ b/src/components/ConnectToWalletButton.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react'
+import { Button } from 'evergreen-ui'
+
+function truncateAddress (address) {
+  return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`
+}
+
+function isMetaMask () { return window.ethereum?.isMetaMask }
+
+function ConnectToWalletButton (props) {
+  const [address, setAddress] = useState(window.ethereum?.selectedAddress)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const firstAddress = (addr) => setAddress(addr[0])
+    window.ethereum?.on('accountsChanged', firstAddress)
+
+    return function cleanup () {
+      window.ethereum?.removeListener('accountsChanged', firstAddress)
+    }
+  }, [])
+
+  async function connectWallet (event) {
+    setLoading(true)
+
+    window.ethereum?.request({ method: 'eth_requestAccounts' })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }
+
+  if (!isMetaMask()) return null
+  return (
+    <Button
+      intent={address ? 'success' : 'none'}
+      style={props.style}
+      isLoading={loading}
+      onClick={connectWallet}
+    >
+      {address ? truncateAddress(address) : 'Connect wallet'}
+    </Button>
+  )
+}
+
+export default ConnectToWalletButton

--- a/src/components/Systems.js
+++ b/src/components/Systems.js
@@ -2,7 +2,6 @@ import React from 'react'
 import {
   majorScale,
   minorScale,
-  Link,
   Pane,
   Text,
   StatusIndicator
@@ -11,15 +10,16 @@ import {
 import { initIPFS, initOrbitDB, getAllDatabases } from '../database'
 import { actions, useStateValue } from '../state'
 
+import ConnectToWalletButton from './ConnectToWalletButton'
+
 function Systems () {
   const [appState, dispatch] = useStateValue()
-
 
   React.useEffect(() => {
     dispatch({ type: actions.PROGRAMS.SET_PROGRAMS_LOADING, loading: true })
 
     initIPFS().then(async (ipfs) => {
-      dispatch({ type: actions.SYSTEMS.SET_IPFS, ipfsStatus: 'Started'})
+      dispatch({ type: actions.SYSTEMS.SET_IPFS, ipfsStatus: 'Started' })
 
       initOrbitDB(ipfs).then(async (databases) => {
         dispatch({ type: actions.SYSTEMS.SET_ORBITDB, orbitdbStatus: 'Started' })
@@ -32,38 +32,35 @@ function Systems () {
   }, [dispatch])
 
   return (
-
     <Pane background='white' elevation={1}>
-      <Pane 
+      <Pane
         display='flex'
-        flexDirection='column'
+        flexDirection='row'
         alignItems='left'
         paddingX={majorScale(6)}
         paddingY={majorScale(1)}
       >
-        <Link href='#/' textDecoration='none' display='flex' flexDirection='row'>
-          <Text fontWeight='600' marginRight={minorScale(1)}>Systems:</Text>
-          <Pane
+        <Pane display='flex' flexDirection='row' width='100%'>
+          <Text
             display='flex'
             alignItems='center'
-            marginX={minorScale(1)}
+            fontWeight='600'
+            marginRight={minorScale(1)}
           >
-            {appState.ipfsStatus === 'Started'
-              ? <StatusIndicator color="success">IPFS</StatusIndicator>
-              : <StatusIndicator color="warning">IPFS</StatusIndicator>
-            }
-          </Pane>
-          <Pane
-            display='flex'
-            alignItems='center'
-            marginX={majorScale(1)}
-          >
-            {appState.orbitdbStatus === 'Started'
-              ? <StatusIndicator color="success">OrbitDB</StatusIndicator>
-              : <StatusIndicator color="warning">OrbitDB</StatusIndicator>
-            }
-          </Pane>
-        </Link>
+            Systems:
+          </Text>
+          {
+            appState.ipfsStatus === 'Started'
+              ? <StatusIndicator color='success'>IPFS</StatusIndicator>
+              : <StatusIndicator color='warning'>IPFS</StatusIndicator>
+          }
+          {
+            appState.orbitdbStatus === 'Started'
+              ? <StatusIndicator color='success'>OrbitDB</StatusIndicator>
+              : <StatusIndicator color='warning'>OrbitDB</StatusIndicator>
+          }
+          <ConnectToWalletButton style={{ marginLeft: 'auto' }} />
+        </Pane>
       </Pane>
     </Pane>
   )


### PR DESCRIPTION
This PR adds a `ConnectToWalletButton` component to the `Header`.

- The button shows when `window.ethereum` is active and is hidden otherwise
- So far the button only connects to the wallet and updates its text based on `window.ethereum.selectedAddress` and `window.ethereum.on('accountsChanged', ...)`

This should pave the way for a UI that uses the [Ethereum identity provider](https://github.com/orbitdb/orbit-db-identity-provider/blob/main/src/ethereum-identity-provider.js). This can happen in this PR or the next.